### PR TITLE
Corrected license type

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "logging"
   ],
   "author": "Caio Gondim <me@caiogondim.com> (http://caiogondim.com)",
-  "license": "ISC",
+  "license": "MIT",
   "bugs": {
     "url": "https://github.com/caiogondim/logdown/issues"
   },


### PR DESCRIPTION
Reading [license.md](https://github.com/caiogondim/logdown.js/blob/master/license.md), this project uses the [MIT License](https://spdx.org/licenses/MIT.html) and not the [ISC License](https://spdx.org/licenses/ISC.html) (which is the default when creating `package.json` files).