### PR TITLE
Added default export

### DIFF
--- a/dist/logdown.d.ts
+++ b/dist/logdown.d.ts
@@ -1,12 +1,12 @@
 declare class Logdown {
   constructor(options?: Object);
-  public debug(...args: string[]): void;
-  public error(...args: string[]): void;
-  public info(...args: string[]): void;
-  public log(...args: string[]): void;
-  public warn(...args: string[]): void;
+  public debug(...args: any[]): void;
+  public error(...args: any[]): void;
+  public info(...args: any[]): void;
+  public log(...args: any[]): void;
+  public warn(...args: any[]): void;
   public static disable(...args: string[]): void;
   public static enable(...args: string[]): void;
 }
 
-export = Logdown;
+export default Logdown;


### PR DESCRIPTION
Working with Logdown in production I noticed that it misses a default export to work with TypeScript. I also experienced that allowing any type of logging object gives it more flexibility.