### PR TITLE
Deprecated Bower version

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,5 @@
 {
   "name": "logdown",
-  "version": "1.2.4",
   "homepage": "https://github.com/caiogondim/logdown",
   "authors": [
     "Caio Gondim <me@caiogondim.com>"


### PR DESCRIPTION
The `version` attribute of Bower is deprecated: https://github.com/bower/spec/blob/master/json.md#version

Bower is using the versions listed in https://github.com/caiogondim/logdown.js/releases