### PR TITLE
TypeScript definition backward compatibility

### DIFF
--- a/dist/logdown.d.ts
+++ b/dist/logdown.d.ts
@@ -1,12 +1,14 @@
-declare class Logdown {
-  constructor(options?: Object);
-  public debug(...args: any[]): void;
-  public error(...args: any[]): void;
-  public info(...args: any[]): void;
-  public log(...args: any[]): void;
-  public warn(...args: any[]): void;
-  public static disable(...args: string[]): void;
-  public static enable(...args: string[]): void;
-}
+declare module 'logdown' {
+  class Logdown {
+    constructor(options?: Object);
+    public debug(...args: any[]): void;
+    public error(...args: any[]): void;
+    public info(...args: any[]): void;
+    public log(...args: any[]): void;
+    public warn(...args: any[]): void;
+    public static disable(...args: string[]): void;
+    public static enable(...args: string[]): void;
+  }
 
-export default Logdown;
+  export = Logdown;
+}

--- a/readme.md
+++ b/readme.md
@@ -43,7 +43,7 @@ var logger = new Logdown({prefix: 'foo'})
 
 ### Browser
 
-In the browser you can install it through [Bower](http://bower.io).
+In the browser you can install it through [Bower](http://bower.io):
 
 ```bash
 bower install logdown
@@ -55,7 +55,7 @@ var logger = new Logdown({prefix: 'foo'})
 
 ### SystemJS
 
-Using the dynamic module loader [SystemJS](https://github.com/systemjs/systemjs), Logdown can be loaded as a CommonJS module.
+Using the dynamic module loader [SystemJS](https://github.com/systemjs/systemjs), Logdown can be loaded as a CommonJS module:
 
 ```js
 SystemJS.config({
@@ -72,6 +72,13 @@ SystemJS.config({
 System.import('logdown').then(function(Logdown) {
   var logger = new Logdown({prefix: 'foo'}
 });
+```
+
+### TypeScript
+
+```ts
+import Logdown = require("logdown");
+let logger: Logdown = new Logdown({prefix: 'foo'};
 ```
 
 ### Other


### PR DESCRIPTION
Logdown's TypeScript definition could be used with the TypeScript [compiler option](https://www.typescriptlang.org/docs/handbook/compiler-options.html) module "system". Now it can be used with module "system" and module "commonjs".

I also added a section in the Readme on how to use Logdown with TypeScript.