### PR TITLE
Added minified output & source map

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -7,6 +7,7 @@ var header = require('gulp-header')
 var karma = require('karma').server
 var mocha = require('gulp-mocha')
 var rename = require('gulp-rename')
+var sourcemaps = require('gulp-sourcemaps')
 var uglify = require('gulp-uglify')
 
 // Test
@@ -59,10 +60,12 @@ gulp.task('build', function() {
   gulp.src('src/logdown.js')
     .pipe(header(banner, {pkg: pkg}))
     .pipe(gulp.dest('dist'))
+    .pipe(sourcemaps.init())
     .pipe(uglify())
     .pipe(header(banner, {pkg: pkg}))
     .pipe(gulp.dest('./example/lib'))
     .pipe(rename({extname: '.min.js'}))
+    .pipe(sourcemaps.write('.'))
     .pipe(gulp.dest('dist'))
 })
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -57,13 +57,13 @@ gulp.task('build', function() {
     ''].join('\n');
 
   gulp.src('src/logdown.js')
-    .pipe(uglify())
     .pipe(header(banner, {pkg: pkg}))
     .pipe(gulp.dest('dist'))
-    .pipe(rename({
-      basename: 'logdown'
-    }))
+    .pipe(uglify())
+    .pipe(header(banner, {pkg: pkg}))
     .pipe(gulp.dest('./example/lib'))
+    .pipe(rename({extname: '.min.js'}))
+    .pipe(gulp.dest('dist'))
 })
 
 // Development

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "gulp-header": "^1.8.2",
     "gulp-mocha": "^2.2.0",
     "gulp-rename": "^1.2.2",
+    "gulp-sourcemaps": "^2.4.0",
     "gulp-uglify": "^1.5.3",
     "karma": "^0.13.0",
     "karma-chai": "^0.1.0",


### PR DESCRIPTION
This PR creates 3 Logdown versions (all with banner on top) to the following locations:

- `dist/logdown.js`
- `dist/logdown.min.js` (resolves https://github.com/caiogondim/logdown.js/issues/79)
- `example/lib/logdown.js`

There will be also a source map for the minified code in:

- `dist/logdown.min.js.map` (resolves https://github.com/caiogondim/logdown.js/issues/73)
