### PR TITLE
fix: Include TypeScript definitions in release

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   "files": [
     "src/",
     "test/",
-    "dist/"
+    "dist/",
+    "index.d.ts",
   ],
   "scripts": {
     "build": "webpack && cpx dist/logdown.js example/lib && uglifyjs --compress --mangle  --screw-ie8 -- dist/logdown.js > dist/logdown.min.js && gzip dist/logdown.min.js --stdout --best > dist/logdown.min.js.gzip",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "src/",
     "test/",
     "dist/",
-    "index.d.ts",
+    "index.d.ts"
   ],
   "scripts": {
     "build": "webpack && cpx dist/logdown.js example/lib && uglifyjs --compress --mangle  --screw-ie8 -- dist/logdown.js > dist/logdown.min.js && gzip dist/logdown.min.js --stdout --best > dist/logdown.min.js.gzip",


### PR DESCRIPTION
The `index.dts` file was not mentioned within the array of files which will be uploaded to npm, thus the TypeScript definition files haven't been released. 