### PR TITLE
fix: transports is not constant

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -19,7 +19,7 @@ declare namespace logdown {
     state: LoggerState;
   }
 
-  const transports: TransportFunction[];
+  let transports: TransportFunction[];
 
   class Logger {
     constructor(prefix: string, opts?: LogdownOptions);


### PR DESCRIPTION
As [visible in the readme](https://github.com/caiogondim/logdown.js/blob/master/readme.md#additional-transports-integration), the `transports` variable is not a constant and can be overwritten.