### PR TITLE
fix(types): Fix types to add transports to logdown

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -19,7 +19,7 @@ declare namespace logdown {
     state: LoggerState;
   }
 
-  const transports: TransportFunction[];
+  let transports: TransportFunction[];
 
   class Logger {
     constructor(prefix: string, opts?: LogdownOptions);


### PR DESCRIPTION
Fixed the issue with Typescript not being happy with assignment to transports
The reason being right now it is set to be a const, and upon assignment, it is throwing errors.