### PR TITLE
fix: Add logger.log fallback for older browsers

### DIFF
--- a/src/base.js
+++ b/src/base.js
@@ -126,7 +126,11 @@ module.exports = function () {
 
           if (this.state.isEnabled) {
             var preparedOutput = this._prepareOutput(args, method)
-            logger[method].apply(logger, preparedOutput)
+            var loggerMethod = logger[method]
+            if (typeof loggerMethod !== 'function') {
+              loggerMethod = logger.log
+            }
+            loggerMethod.apply(logger, preparedOutput)
           }
         }
       })


### PR DESCRIPTION
On older browsers there could be no `.info` or `.error` method available. In that case we silently fail and use `.log`.

Fixes https://github.com/caiogondim/logdown.js/issues/212.