### PR TITLE
feat: Add "debug" to minimum API

### DIFF
--- a/src/base.js
+++ b/src/base.js
@@ -98,7 +98,7 @@ module.exports = function () {
     // In old Safari and Chrome browsers, `console` methods are not iterable.
     // In that case, we provide a minimum API.
     if (loggerMethods.length === 0) {
-      loggerMethods = ['log', 'warn', 'error', 'info']
+      loggerMethods = ['debug', 'log', 'warn', 'error', 'info']
     }
 
     loggerMethods


### PR DESCRIPTION
In our TypeScript definition file we expose the following log methods:

```ts
    debug(...args: any[]): void;
    error(...args: any[]): void;
    info(...args: any[]): void;
    log(...args: any[]): void;
    warn(...args: any[]): void;
```

That's why we should also include `debug` to the minimum API that we use in our fallback case.